### PR TITLE
Add Node.js backend and integrate API-driven frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "node server/index.js",
     "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.6.8",
+    "cors": "^2.8.5",
+    "express": "^4.18.3",
     "element-plus": "^2.4.3",
     "vue": "^3.3.4",
     "vue-router": "^4.2.2"

--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,22 @@
 
 ```bash
 pnpm install
+
+# 启动后端接口服务（默认端口 3000）
+pnpm server
+
+# 另开一个终端启动前端
 pnpm dev
 ```
 
-默认会在 http://localhost:5173 启动 Vite 开发服务器。
+默认会在 http://localhost:5173 启动 Vite 开发服务器，前端通过 `http://localhost:3000/api` 访问后端。
 
 ### 项目结构
 
 - `src/views/BookList.vue`：书籍列表与维护操作。
 - `src/views/CopyDetails.vue`：书籍副本管理与借阅记录。
-- `src/store/libraryStore.js`：前端内存状态及示例数据。
+- `src/store/libraryStore.js`：与后端接口交互的状态管理封装。
+- `server/index.js`：基于 Express 的后端入口，提供图书与副本 REST 接口。
+- `server/libraryService.js`：后端数据读写与业务逻辑实现。
+- `server/data/library.json`：初始数据及简单的 JSON 数据库。
 - `src/router/index.js`：前端路由配置。

--- a/server/data/library.json
+++ b/server/data/library.json
@@ -1,0 +1,134 @@
+{
+  "books": [
+    {
+      "id": "B2023-001",
+      "name": "Vue 3 实战指南",
+      "author": "张伟",
+      "publisher": "电子工业出版社",
+      "publishDate": "2023-04-02",
+      "price": 88,
+      "pages": 432,
+      "isbn": "9787121428854",
+      "quantity": 3,
+      "entryDate": "2023-04-16",
+      "borrowCount": 26,
+      "status": "normal",
+      "copies": [
+        {
+          "id": "B2023-001-01",
+          "location": "一楼 A 区 01 架",
+          "status": "available",
+          "borrowCount": 12,
+          "borrowRecords": [
+            {
+              "borrower": "李雷",
+              "borrowTime": "2023-05-01 10:00",
+              "returnTime": "2023-05-21 14:30"
+            },
+            {
+              "borrower": "韩梅梅",
+              "borrowTime": "2023-07-18 09:30",
+              "returnTime": "2023-08-02 16:20"
+            }
+          ]
+        },
+        {
+          "id": "B2023-001-02",
+          "location": "一楼 A 区 01 架",
+          "status": "borrowed",
+          "borrowCount": 9,
+          "borrowRecords": [
+            {
+              "borrower": "王芳",
+              "borrowTime": "2023-09-06 11:10",
+              "returnTime": "2023-09-28 18:40"
+            },
+            {
+              "borrower": "陈强",
+              "borrowTime": "2023-10-12 15:25",
+              "returnTime": ""
+            }
+          ]
+        },
+        {
+          "id": "B2023-001-03",
+          "location": "一楼 A 区 02 架",
+          "status": "pending",
+          "borrowCount": 5,
+          "borrowRecords": []
+        }
+      ]
+    },
+    {
+      "id": "B2022-035",
+      "name": "数据库系统概念",
+      "author": "Abraham Silberschatz",
+      "publisher": "机械工业出版社",
+      "publishDate": "2021-12-10",
+      "price": 128,
+      "pages": 900,
+      "isbn": "9787111658596",
+      "quantity": 2,
+      "entryDate": "2022-01-05",
+      "borrowCount": 48,
+      "status": "allBorrowed",
+      "copies": [
+        {
+          "id": "B2022-035-01",
+          "location": "二楼 B 区 11 架",
+          "status": "borrowed",
+          "borrowCount": 25,
+          "borrowRecords": [
+            {
+              "borrower": "赵云",
+              "borrowTime": "2023-08-15 13:15",
+              "returnTime": ""
+            }
+          ]
+        },
+        {
+          "id": "B2022-035-02",
+          "location": "二楼 B 区 11 架",
+          "status": "damaged",
+          "borrowCount": 23,
+          "borrowRecords": [
+            {
+              "borrower": "刘备",
+              "borrowTime": "2023-05-10 10:05",
+              "returnTime": "2023-05-30 09:50"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "B2021-120",
+      "name": "Python 编程：从入门到实践",
+      "author": "埃里克·马瑟斯",
+      "publisher": "人民邮电出版社",
+      "publishDate": "2020-06-01",
+      "price": 89,
+      "pages": 632,
+      "isbn": "9787115533073",
+      "quantity": 1,
+      "entryDate": "2021-03-20",
+      "borrowCount": 54,
+      "status": "forbidden",
+      "copies": [
+        {
+          "id": "B2021-120-01",
+          "location": "二楼 C 区 03 架",
+          "status": "lost",
+          "borrowCount": 54,
+          "borrowRecords": [
+            {
+              "borrower": "周瑜",
+              "borrowTime": "2022-11-01 09:00",
+              "returnTime": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,135 @@
+import express from 'express'
+import cors from 'cors'
+import {
+  initLibrary,
+  listBooks,
+  findBookById,
+  createBook,
+  updateBookById,
+  removeBookById,
+  addCopyToBook,
+  updateCopyOfBook,
+  removeCopyFromBook,
+  borrowCopyFromBook,
+  returnCopyToBook,
+  archiveCopyOfBook,
+  HttpError
+} from './libraryService.js'
+
+const app = express()
+const PORT = Number(process.env.PORT) || 3000
+
+app.use(cors())
+app.use(express.json())
+
+await initLibrary()
+
+app.get('/api/books', (req, res) => {
+  res.json(listBooks())
+})
+
+app.get('/api/books/:id', (req, res) => {
+  const book = findBookById(req.params.id)
+  if (!book) {
+    res.status(404).json({ message: '未找到对应的书籍' })
+    return
+  }
+  res.json(book)
+})
+
+app.post('/api/books', async (req, res) => {
+  try {
+    const book = await createBook(req.body ?? {})
+    res.status(201).json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.put('/api/books/:id', async (req, res) => {
+  try {
+    const book = await updateBookById(req.params.id, req.body ?? {})
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.delete('/api/books/:id', async (req, res) => {
+  try {
+    await removeBookById(req.params.id)
+    res.status(204).end()
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.post('/api/books/:id/copies', async (req, res) => {
+  try {
+    const book = await addCopyToBook(req.params.id, req.body ?? {})
+    res.status(201).json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.put('/api/books/:bookId/copies/:copyId', async (req, res) => {
+  try {
+    const book = await updateCopyOfBook(req.params.bookId, req.params.copyId, req.body ?? {})
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.delete('/api/books/:bookId/copies/:copyId', async (req, res) => {
+  try {
+    const book = await removeCopyFromBook(req.params.bookId, req.params.copyId)
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.post('/api/books/:bookId/copies/:copyId/borrow', async (req, res) => {
+  try {
+    const book = await borrowCopyFromBook(req.params.bookId, req.params.copyId, req.body ?? {})
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.post('/api/books/:bookId/copies/:copyId/return', async (req, res) => {
+  try {
+    const book = await returnCopyToBook(req.params.bookId, req.params.copyId, req.body ?? {})
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.post('/api/books/:bookId/copies/:copyId/archive', async (req, res) => {
+  try {
+    const book = await archiveCopyOfBook(req.params.bookId, req.params.copyId)
+    res.json(book)
+  } catch (error) {
+    handleError(res, error)
+  }
+})
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Library API server is running at http://localhost:${PORT}`)
+})
+
+function handleError(res, error) {
+  if (error instanceof HttpError) {
+    res.status(error.status).json({ message: error.message })
+    return
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(error)
+  res.status(500).json({ message: '服务器内部错误' })
+}

--- a/server/libraryService.js
+++ b/server/libraryService.js
@@ -1,0 +1,447 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+export const BOOK_STATUS = {
+  NORMAL: 'normal',
+  ALL_BORROWED: 'allBorrowed',
+  FORBIDDEN: 'forbidden'
+}
+
+export const COPY_STATUS = {
+  AVAILABLE: 'available',
+  LOST: 'lost',
+  DAMAGED: 'damaged',
+  BORROWED: 'borrowed',
+  PENDING: 'pending'
+}
+
+export class HttpError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.status = status
+  }
+}
+
+const BOOK_STATUS_VALUES = Object.values(BOOK_STATUS)
+const COPY_STATUS_VALUES = Object.values(COPY_STATUS)
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const dataFilePath = path.resolve(__dirname, 'data', 'library.json')
+
+let libraryData = { books: [] }
+
+export async function initLibrary() {
+  libraryData = await readDataFile()
+  if (!Array.isArray(libraryData.books)) {
+    libraryData.books = []
+  }
+
+  libraryData.books.forEach((book) => {
+    normalizeBook(book)
+    recalculateBookState(book)
+  })
+}
+
+export function listBooks() {
+  return libraryData.books
+}
+
+export function findBookById(bookId) {
+  return libraryData.books.find((book) => book.id === bookId)
+}
+
+export async function createBook(payload) {
+  const name = (payload.name ?? '').toString().trim()
+  if (!name) {
+    throw new HttpError(400, '书籍名称不能为空')
+  }
+
+  const desiredId = payload.id ? payload.id.toString().trim() : ''
+  const bookId = desiredId || generateBookId()
+  if (libraryData.books.some((item) => item.id === bookId)) {
+    throw new HttpError(400, '书籍编号已存在')
+  }
+
+  const book = {
+    id: bookId,
+    name,
+    author: (payload.author ?? '').toString().trim(),
+    publisher: (payload.publisher ?? '').toString().trim(),
+    publishDate: (payload.publishDate ?? '').toString().trim(),
+    price: toNumber(payload.price),
+    pages: toNumber(payload.pages),
+    isbn: (payload.isbn ?? '').toString().trim(),
+    entryDate: (payload.entryDate ?? '').toString().trim(),
+    borrowCount: toNumber(payload.borrowCount),
+    status: normalizeBookStatus(payload.status),
+    copies: []
+  }
+
+  if (Array.isArray(payload.copies) && payload.copies.length) {
+    book.copies = payload.copies.map((copy) => normalizeCopy(copy))
+  }
+
+  recalculateBookState(book)
+  libraryData.books.unshift(book)
+  await persist()
+  return book
+}
+
+export async function updateBookById(originalId, payload) {
+  const book = ensureBook(originalId)
+
+  if (payload.id !== undefined) {
+    const newId = payload.id.toString().trim()
+    if (!newId) {
+      throw new HttpError(400, '书籍编号不能为空')
+    }
+    if (newId !== originalId && libraryData.books.some((item) => item.id === newId)) {
+      throw new HttpError(400, '新的书籍编号已存在')
+    }
+    book.id = newId
+  }
+
+  if (payload.name !== undefined) {
+    const value = payload.name.toString().trim()
+    if (!value) {
+      throw new HttpError(400, '书籍名称不能为空')
+    }
+    book.name = value
+  }
+
+  if (payload.author !== undefined) {
+    book.author = payload.author.toString().trim()
+  }
+
+  if (payload.publisher !== undefined) {
+    book.publisher = payload.publisher.toString().trim()
+  }
+
+  if (payload.publishDate !== undefined) {
+    book.publishDate = payload.publishDate.toString().trim()
+  }
+
+  if (payload.price !== undefined) {
+    book.price = toNumber(payload.price)
+  }
+
+  if (payload.pages !== undefined) {
+    book.pages = toNumber(payload.pages)
+  }
+
+  if (payload.isbn !== undefined) {
+    book.isbn = payload.isbn.toString().trim()
+  }
+
+  if (payload.entryDate !== undefined) {
+    book.entryDate = payload.entryDate.toString().trim()
+  }
+
+  if (payload.borrowCount !== undefined) {
+    book.borrowCount = toNumber(payload.borrowCount)
+  }
+
+  if (payload.status !== undefined) {
+    book.status = normalizeBookStatus(payload.status)
+  }
+
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function removeBookById(bookId) {
+  const index = libraryData.books.findIndex((book) => book.id === bookId)
+  if (index === -1) {
+    throw new HttpError(404, '未找到对应的书籍')
+  }
+  libraryData.books.splice(index, 1)
+  await persist()
+}
+
+export async function addCopyToBook(bookId, payload) {
+  const book = ensureBook(bookId)
+  const copyId = payload.id ? payload.id.toString().trim() : generateCopyId(book)
+  if (!copyId) {
+    throw new HttpError(400, '副本编号不能为空')
+  }
+  if (book.copies.some((item) => item.id === copyId)) {
+    throw new HttpError(400, '副本编号已存在')
+  }
+
+  const copy = normalizeCopy({
+    ...payload,
+    id: copyId
+  })
+
+  book.copies.unshift(copy)
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function updateCopyOfBook(bookId, copyId, payload) {
+  const book = ensureBook(bookId)
+  const copy = ensureCopy(book, copyId)
+
+  if (payload.id !== undefined) {
+    const newId = payload.id.toString().trim()
+    if (!newId) {
+      throw new HttpError(400, '副本编号不能为空')
+    }
+    if (newId !== copyId && book.copies.some((item) => item.id === newId)) {
+      throw new HttpError(400, '新的副本编号已存在')
+    }
+    copy.id = newId
+  }
+
+  if (payload.location !== undefined) {
+    copy.location = payload.location.toString().trim()
+  }
+
+  if (payload.status !== undefined) {
+    copy.status = normalizeCopyStatus(payload.status)
+  }
+
+  if (payload.borrowCount !== undefined) {
+    copy.borrowCount = toNumber(payload.borrowCount)
+  }
+
+  if (payload.borrowRecords !== undefined && Array.isArray(payload.borrowRecords)) {
+    copy.borrowRecords = payload.borrowRecords.map((record) => normalizeBorrowRecord(record))
+  }
+
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function removeCopyFromBook(bookId, copyId) {
+  const book = ensureBook(bookId)
+  const index = book.copies.findIndex((item) => item.id === copyId)
+  if (index === -1) {
+    throw new HttpError(404, '未找到对应的副本')
+  }
+
+  book.copies.splice(index, 1)
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function borrowCopyFromBook(bookId, copyId, payload) {
+  const book = ensureBook(bookId)
+  const copy = ensureCopy(book, copyId)
+
+  if (copy.status === COPY_STATUS.BORROWED) {
+    throw new HttpError(400, '该副本已被借出')
+  }
+
+  const borrower = (payload.borrower ?? '').toString().trim()
+  if (!borrower) {
+    throw new HttpError(400, '借阅人不能为空')
+  }
+
+  const borrowTime = (payload.borrowTime ?? '').toString().trim() || formatDateTime(new Date())
+
+  copy.status = COPY_STATUS.BORROWED
+  copy.borrowCount = toNumber(copy.borrowCount) + 1
+  copy.borrowRecords.push({
+    borrower,
+    borrowTime,
+    returnTime: ''
+  })
+  book.borrowCount = toNumber(book.borrowCount) + 1
+
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function returnCopyToBook(bookId, copyId, payload = {}) {
+  const book = ensureBook(bookId)
+  const copy = ensureCopy(book, copyId)
+
+  if (copy.status !== COPY_STATUS.BORROWED) {
+    throw new HttpError(400, '该副本未处于借出状态')
+  }
+
+  const returnTime = (payload.returnTime ?? '').toString().trim() || formatDateTime(new Date())
+
+  copy.status = COPY_STATUS.AVAILABLE
+  const record = findLatestBorrowRecord(copy)
+  if (record) {
+    record.returnTime = returnTime
+  }
+
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+export async function archiveCopyOfBook(bookId, copyId) {
+  const book = ensureBook(bookId)
+  const copy = ensureCopy(book, copyId)
+
+  copy.status = COPY_STATUS.AVAILABLE
+  recalculateBookState(book)
+  await persist()
+  return book
+}
+
+function ensureBook(bookId) {
+  const book = findBookById(bookId)
+  if (!book) {
+    throw new HttpError(404, '未找到对应的书籍')
+  }
+  return book
+}
+
+function ensureCopy(book, copyId) {
+  const copy = book.copies.find((item) => item.id === copyId)
+  if (!copy) {
+    throw new HttpError(404, '未找到对应的副本')
+  }
+  return copy
+}
+
+function normalizeBook(book) {
+  book.name = (book.name ?? '').toString().trim()
+  book.author = (book.author ?? '').toString().trim()
+  book.publisher = (book.publisher ?? '').toString().trim()
+  book.publishDate = (book.publishDate ?? '').toString().trim()
+  book.price = toNumber(book.price)
+  book.pages = toNumber(book.pages)
+  book.isbn = (book.isbn ?? '').toString().trim()
+  book.entryDate = (book.entryDate ?? '').toString().trim()
+  book.borrowCount = toNumber(book.borrowCount)
+  book.status = normalizeBookStatus(book.status)
+  book.copies = Array.isArray(book.copies) ? book.copies.map((copy) => normalizeCopy(copy)) : []
+  book.quantity = book.copies.length
+}
+
+function normalizeCopy(copy) {
+  return {
+    id: (copy.id ?? '').toString().trim(),
+    location: (copy.location ?? '').toString().trim(),
+    status: normalizeCopyStatus(copy.status),
+    borrowCount: toNumber(copy.borrowCount),
+    borrowRecords: Array.isArray(copy.borrowRecords)
+      ? copy.borrowRecords.map((record) => normalizeBorrowRecord(record))
+      : []
+  }
+}
+
+function normalizeBorrowRecord(record) {
+  return {
+    borrower: (record?.borrower ?? '').toString().trim(),
+    borrowTime: (record?.borrowTime ?? '').toString().trim(),
+    returnTime: (record?.returnTime ?? '').toString().trim()
+  }
+}
+
+function normalizeBookStatus(status) {
+  if (!status) {
+    return BOOK_STATUS.NORMAL
+  }
+  const value = status.toString().trim()
+  if (!BOOK_STATUS_VALUES.includes(value)) {
+    throw new HttpError(400, '无效的书籍状态')
+  }
+  return value
+}
+
+function normalizeCopyStatus(status) {
+  if (!status) {
+    return COPY_STATUS.PENDING
+  }
+  const value = status.toString().trim()
+  if (!COPY_STATUS_VALUES.includes(value)) {
+    throw new HttpError(400, '无效的副本状态')
+  }
+  return value
+}
+
+function recalculateBookState(book) {
+  book.quantity = book.copies.length
+
+  if (book.status === BOOK_STATUS.FORBIDDEN) {
+    return
+  }
+
+  const hasAvailable = book.copies.some((copy) => copy.status === COPY_STATUS.AVAILABLE || copy.status === COPY_STATUS.PENDING)
+  const hasCopies = book.copies.length > 0
+  const allBorrowed = hasCopies && book.copies.every((copy) => copy.status === COPY_STATUS.BORROWED)
+
+  if (allBorrowed) {
+    book.status = BOOK_STATUS.ALL_BORROWED
+  } else if (hasAvailable || !hasCopies) {
+    book.status = BOOK_STATUS.NORMAL
+  }
+}
+
+function findLatestBorrowRecord(copy) {
+  for (let i = copy.borrowRecords.length - 1; i >= 0; i -= 1) {
+    if (!copy.borrowRecords[i].returnTime) {
+      return copy.borrowRecords[i]
+    }
+  }
+  return null
+}
+
+function generateBookId() {
+  return `B${Date.now()}`
+}
+
+function generateCopyId(book) {
+  const prefix = `${book.id}-`
+  const numericSuffixes = book.copies
+    .map((copy) => copy.id)
+    .filter((id) => id.startsWith(prefix))
+    .map((id) => parseInt(id.slice(prefix.length), 10))
+    .filter((value) => Number.isFinite(value))
+
+  const next = (numericSuffixes.length ? Math.max(...numericSuffixes) + 1 : 1)
+  return `${prefix}${String(next).padStart(2, '0')}`
+}
+
+function toNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) && number >= 0 ? number : 0
+}
+
+function formatDateTime(date) {
+  const d = date instanceof Date ? date : new Date(date)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const hour = String(d.getHours()).padStart(2, '0')
+  const minute = String(d.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hour}:${minute}`
+}
+
+async function persist() {
+  await fs.mkdir(path.dirname(dataFilePath), { recursive: true })
+  await fs.writeFile(dataFilePath, JSON.stringify(libraryData, null, 2), 'utf-8')
+}
+
+async function readDataFile() {
+  try {
+    const content = await fs.readFile(dataFilePath, 'utf-8')
+    return JSON.parse(content)
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFilePath), { recursive: true })
+      const initialData = { books: [] }
+      await fs.writeFile(dataFilePath, JSON.stringify(initialData, null, 2), 'utf-8')
+      return initialData
+    }
+    throw error
+  }
+}
+
+export function formatDateTimeForNow() {
+  return formatDateTime(new Date())
+}

--- a/src/store/libraryStore.js
+++ b/src/store/libraryStore.js
@@ -1,4 +1,5 @@
 import { reactive } from 'vue'
+import axios from 'axios'
 
 export const BOOK_STATUS = {
   NORMAL: 'normal',
@@ -28,263 +29,148 @@ export const COPY_STATUS_TEXT = {
   [COPY_STATUS.PENDING]: '未归档'
 }
 
-const now = new Date()
-const formatDate = (date) => {
-  const d = new Date(date)
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api'
 
-const today = formatDate(now)
-
-export const libraryStore = reactive({
-  books: [
-    {
-      id: 'B2023-001',
-      name: 'Vue 3 实战指南',
-      author: '张伟',
-      publisher: '电子工业出版社',
-      publishDate: '2023-04-02',
-      price: 88,
-      pages: 432,
-      isbn: '9787121428854',
-      quantity: 3,
-      entryDate: '2023-04-16',
-      borrowCount: 26,
-      status: BOOK_STATUS.NORMAL,
-      copies: [
-        {
-          id: 'B2023-001-01',
-          location: '一楼 A 区 01 架',
-          status: COPY_STATUS.AVAILABLE,
-          borrowCount: 12,
-          borrowRecords: [
-            {
-              borrower: '李雷',
-              borrowTime: '2023-05-01 10:00',
-              returnTime: '2023-05-21 14:30'
-            },
-            {
-              borrower: '韩梅梅',
-              borrowTime: '2023-07-18 09:30',
-              returnTime: '2023-08-02 16:20'
-            }
-          ]
-        },
-        {
-          id: 'B2023-001-02',
-          location: '一楼 A 区 01 架',
-          status: COPY_STATUS.BORROWED,
-          borrowCount: 9,
-          borrowRecords: [
-            {
-              borrower: '王芳',
-              borrowTime: '2023-09-06 11:10',
-              returnTime: '2023-09-28 18:40'
-            },
-            {
-              borrower: '陈强',
-              borrowTime: '2023-10-12 15:25',
-              returnTime: ''
-            }
-          ]
-        },
-        {
-          id: 'B2023-001-03',
-          location: '一楼 A 区 02 架',
-          status: COPY_STATUS.PENDING,
-          borrowCount: 5,
-          borrowRecords: []
-        }
-      ]
-    },
-    {
-      id: 'B2022-035',
-      name: '数据库系统概念',
-      author: 'Abraham Silberschatz',
-      publisher: '机械工业出版社',
-      publishDate: '2021-12-10',
-      price: 128,
-      pages: 900,
-      isbn: '9787111658596',
-      quantity: 2,
-      entryDate: '2022-01-05',
-      borrowCount: 48,
-      status: BOOK_STATUS.ALL_BORROWED,
-      copies: [
-        {
-          id: 'B2022-035-01',
-          location: '二楼 B 区 11 架',
-          status: COPY_STATUS.BORROWED,
-          borrowCount: 25,
-          borrowRecords: [
-            {
-              borrower: '赵云',
-              borrowTime: '2023-08-15 13:15',
-              returnTime: ''
-            }
-          ]
-        },
-        {
-          id: 'B2022-035-02',
-          location: '二楼 B 区 11 架',
-          status: COPY_STATUS.DAMAGED,
-          borrowCount: 23,
-          borrowRecords: [
-            {
-              borrower: '刘备',
-              borrowTime: '2023-05-10 10:05',
-              returnTime: '2023-05-30 09:50'
-            }
-          ]
-        }
-      ]
-    },
-    {
-      id: 'B2021-120',
-      name: 'Python 编程：从入门到实践',
-      author: '埃里克·马瑟斯',
-      publisher: '人民邮电出版社',
-      publishDate: '2020-06-01',
-      price: 89,
-      pages: 632,
-      isbn: '9787115533073',
-      quantity: 1,
-      entryDate: '2021-03-20',
-      borrowCount: 54,
-      status: BOOK_STATUS.FORBIDDEN,
-      copies: [
-        {
-          id: 'B2021-120-01',
-          location: '二楼 C 区 03 架',
-          status: COPY_STATUS.LOST,
-          borrowCount: 54,
-          borrowRecords: [
-            {
-              borrower: '周瑜',
-              borrowTime: '2022-11-01 09:00',
-              returnTime: ''
-            }
-          ]
-        }
-      ]
-    }
-  ]
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000
 })
 
-export function getBooks() {
-  return libraryStore.books
+export const libraryStore = reactive({
+  books: [],
+  loading: false,
+  error: null,
+  initialized: false
+})
+
+function setError(message) {
+  libraryStore.error = message
+}
+
+function clearError() {
+  libraryStore.error = null
+}
+
+function getErrorMessage(error, fallback = '请求失败') {
+  return error?.response?.data?.message || error?.message || fallback
+}
+
+export async function fetchBooks() {
+  libraryStore.loading = true
+  try {
+    const { data } = await apiClient.get('/books')
+    libraryStore.books = data
+    libraryStore.initialized = true
+    clearError()
+    return data
+  } catch (error) {
+    const message = getErrorMessage(error, '获取书籍数据失败')
+    setError(message)
+    throw error
+  } finally {
+    libraryStore.loading = false
+  }
+}
+
+export async function ensureBooksLoaded() {
+  if (!libraryStore.initialized) {
+    await fetchBooks()
+  }
 }
 
 export function getBookById(id) {
   return libraryStore.books.find((book) => book.id === id)
 }
 
-export function addBook(book) {
-  libraryStore.books.unshift({
-    ...book,
-    id: book.id || `B${Date.now()}`,
-    quantity: book.copies?.length ?? book.quantity ?? 0,
-    copies: book.copies ?? []
-  })
+function replaceBook(originalId, updatedBook) {
+  if (!updatedBook) return
+
+  const originalIndex = originalId
+    ? libraryStore.books.findIndex((item) => item.id === originalId)
+    : -1
+
+  if (originalIndex !== -1) {
+    libraryStore.books[originalIndex] = updatedBook
+    return
+  }
+
+  const currentIndex = libraryStore.books.findIndex((item) => item.id === updatedBook.id)
+  if (currentIndex !== -1) {
+    libraryStore.books[currentIndex] = updatedBook
+    return
+  }
+
+  libraryStore.books.unshift(updatedBook)
 }
 
-export function updateBook(bookId, payload) {
-  const target = getBookById(bookId)
-  if (!target) return
-  Object.assign(target, payload)
-  target.quantity = target.copies.length
+export async function addBook(payload) {
+  const { data } = await apiClient.post('/books', payload)
+  libraryStore.books.unshift(data)
+  return data
 }
 
-export function removeBook(bookId) {
-  const index = libraryStore.books.findIndex((item) => item.id === bookId)
+export async function updateBook(bookId, payload) {
+  const { data } = await apiClient.put(`/books/${encodeURIComponent(bookId)}`, payload)
+  replaceBook(bookId, data)
+  return data
+}
+
+export async function removeBook(bookId) {
+  await apiClient.delete(`/books/${encodeURIComponent(bookId)}`)
+  const index = libraryStore.books.findIndex((book) => book.id === bookId)
   if (index !== -1) {
     libraryStore.books.splice(index, 1)
   }
 }
 
-export function addCopy(bookId, copy) {
-  const book = getBookById(bookId)
-  if (!book) return
-  book.copies.unshift({
-    borrowCount: 0,
-    borrowRecords: [],
-    ...copy
-  })
-  book.quantity = book.copies.length
-  updateBookBorrowStatus(book)
+function updateBookFromResponse(bookId, responseBook) {
+  replaceBook(bookId, responseBook)
+  return responseBook
 }
 
-export function updateCopy(bookId, copyId, payload) {
-  const book = getBookById(bookId)
-  if (!book) return
-  const copy = book.copies.find((item) => item.id === copyId)
-  if (!copy) return
-  Object.assign(copy, payload)
-  updateBookBorrowStatus(book)
+export async function addCopy(bookId, payload) {
+  const { data } = await apiClient.post(`/books/${encodeURIComponent(bookId)}/copies`, payload)
+  return updateBookFromResponse(bookId, data)
 }
 
-export function removeCopy(bookId, copyId) {
-  const book = getBookById(bookId)
-  if (!book) return
-  const index = book.copies.findIndex((item) => item.id === copyId)
-  if (index !== -1) {
-    book.copies.splice(index, 1)
-    book.quantity = book.copies.length
-    updateBookBorrowStatus(book)
-  }
+export async function updateCopy(bookId, copyId, payload) {
+  const { data } = await apiClient.put(
+    `/books/${encodeURIComponent(bookId)}/copies/${encodeURIComponent(copyId)}`,
+    payload
+  )
+  return updateBookFromResponse(bookId, data)
 }
 
-export function borrowCopy(bookId, copyId, record) {
-  const book = getBookById(bookId)
-  if (!book) return
-  const copy = book.copies.find((item) => item.id === copyId)
-  if (!copy) return
-  copy.status = COPY_STATUS.BORROWED
-  copy.borrowCount += 1
-  copy.borrowRecords.push({ ...record, returnTime: '' })
-  book.borrowCount += 1
-  updateBookBorrowStatus(book)
+export async function removeCopy(bookId, copyId) {
+  const { data } = await apiClient.delete(
+    `/books/${encodeURIComponent(bookId)}/copies/${encodeURIComponent(copyId)}`
+  )
+  return updateBookFromResponse(bookId, data)
 }
 
-export function returnCopy(bookId, copyId, returnTime = `${today} 10:00`) {
-  const book = getBookById(bookId)
-  if (!book) return
-  const copy = book.copies.find((item) => item.id === copyId)
-  if (!copy) return
-  copy.status = COPY_STATUS.AVAILABLE
-  const latestRecord = [...copy.borrowRecords].reverse().find((item) => !item.returnTime)
-  if (latestRecord) {
-    latestRecord.returnTime = returnTime
-  }
-  updateBookBorrowStatus(book)
+export async function borrowCopy(bookId, copyId, payload) {
+  const { data } = await apiClient.post(
+    `/books/${encodeURIComponent(bookId)}/copies/${encodeURIComponent(copyId)}/borrow`,
+    payload
+  )
+  return updateBookFromResponse(bookId, data)
 }
 
-export function archiveCopy(bookId, copyId) {
-  const book = getBookById(bookId)
-  if (!book) return
-  const copy = book.copies.find((item) => item.id === copyId)
-  if (!copy) return
-  copy.status = COPY_STATUS.AVAILABLE
-  updateBookBorrowStatus(book)
+export async function returnCopy(bookId, copyId, payload) {
+  const { data } = await apiClient.post(
+    `/books/${encodeURIComponent(bookId)}/copies/${encodeURIComponent(copyId)}/return`,
+    payload
+  )
+  return updateBookFromResponse(bookId, data)
 }
 
-export function updateBookBorrowStatus(book) {
-  const hasAvailable = book.copies.some((copy) => copy.status === COPY_STATUS.AVAILABLE || copy.status === COPY_STATUS.PENDING)
-  const allBorrowed = book.copies.every((copy) => copy.status === COPY_STATUS.BORROWED)
-  if (book.status !== BOOK_STATUS.FORBIDDEN) {
-    if (allBorrowed) {
-      book.status = BOOK_STATUS.ALL_BORROWED
-    } else if (hasAvailable) {
-      book.status = BOOK_STATUS.NORMAL
-    }
-  }
+export async function archiveCopy(bookId, copyId) {
+  const { data } = await apiClient.post(
+    `/books/${encodeURIComponent(bookId)}/copies/${encodeURIComponent(copyId)}/archive`
+  )
+  return updateBookFromResponse(bookId, data)
 }
 
-export function resetBookQuantities() {
-  libraryStore.books.forEach((book) => {
-    book.quantity = book.copies.length
-  })
+export function resolveApiError(error, fallback = '操作失败') {
+  return getErrorMessage(error, fallback)
 }


### PR DESCRIPTION
## Summary
- add an Express-based backend that persists library data to JSON and exposes CRUD routes for books and copies
- refactor the Vue store to load data through Axios, surface loading/error states, and synchronize local state with API responses
- update book and copy views to call the async store methods, handle API failures, and refresh borrow records accordingly
- document the new server script and development workflow in the README

## Testing
- node --check server/libraryService.js
- node --check server/index.js
- node --check src/store/libraryStore.js
- pnpm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ce598cdbb883239e08c73d8ffe9a94